### PR TITLE
Add hashset with basic operations and tests

### DIFF
--- a/goldfish/liii/hashset.scm
+++ b/goldfish/liii/hashset.scm
@@ -1,0 +1,68 @@
+;
+; Copyright (C) 2025 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(define-library (liii hashset)
+(import (liii lang)
+        (srfi srfi-125)
+        (srfi srfi-128))
+(export hashset)
+(begin
+
+(define case-class-comparator
+  (begin
+    (define (base-type? x) (???))
+    (define (type-test x)
+      (or (base-type? x)
+          (case-class? x)))
+    (define equality ==)
+    (define ordering #t)
+    (define (hash x)
+      (if (base-type? x)
+        (hash-code x)
+        (x :hash-code)))  ; not implemented
+    (make-comparator type-test equality ordering hash)))
+
+(define-case-class hashset ((data hash-table?) (comparator comparator?))
+  (define (%contains x)
+    (hash-table-contains? data x))
+
+  (chained-define (@empty) (hashset (make-hash-table) (make-default-comparator)))
+
+  (chained-define (%add! x)
+    (hash-table-set! data x #t)
+    (%this))
+
+  (chained-define (%remove! x)
+    (hash-table-delete! data x)
+    (%this))
+
+  (define (%internal-table) data)
+
+  (chained-define (%concat other)
+    (define ht (copy data))
+    (hash-table-for-each
+      (lambda (key val)
+        (when (not (equal? val #t))
+          (value-error "unexpected value for hashset"))
+        (hash-table-set! ht key #t))
+      (other :internal-table))
+    (hashset ht comparator))
+
+
+) ; end of hashset
+
+) ; end of begin
+)

--- a/tests/goldfish/liii/hashset-test.scm
+++ b/tests/goldfish/liii/hashset-test.scm
@@ -1,0 +1,39 @@
+;
+; Copyright (C) 2025 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(import (liii check)
+        (liii lang)
+        (liii hashset))
+
+(check-set-mode! 'report-failed)
+
+(let ((hs (hashset :empty)))
+  (check-false (hs :contains 1))
+  (check-false (hs :contains #t))
+  (check-true (hs :add! 1
+                  :add! 2
+                  :contains 1))
+  (check-false (hs :remove! 2
+                   :contains 2)))
+
+(let ((hs1 (hashset :empty :add! 2 :add! 3))
+      (hs2 (hashset :empty :add! 1 :add! 2)))
+  (define hs (hs1 :concat hs2))
+  (check-true (hs :contains 1))
+  (check-true (hs :contains 2))
+  (check-true (hs :contains 3)))
+
+(check-report)


### PR DESCRIPTION
This commit introduces a new `hashset` implementation, including core functionality like `add!`, `remove!`, `contains`, and `concat`. It also includes a corresponding test suite to verify the correctness of the implementation. The hashset is built using SRFI-125 and SRFI-128 for hash tables and comparators.